### PR TITLE
speculative fixes for Gemini issue: TypeError: cannot pickle 'google_upb._message.MessageMapContainer' object

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -27,5 +27,12 @@ mcp_features:
   auto_delete_enabled: true
   auto_purge_enabled: true
 
+# Logging configuration
+logging:
+  # Enable/disable thread-safe logging queue for LLM debug logs
+  # Setting to false may resolve pickle serialization errors with Google Protocol Buffers
+  # but may reduce thread safety in high-concurrency scenarios
+  llm_enqueue_enabled: true  # Set to false if experiencing MapComposite pickle errors
+
 # general:
 #   setting_1: "value" # Example for other potential app settings 

--- a/config/settings.py
+++ b/config/settings.py
@@ -31,6 +31,9 @@ DEFAULT_APP_CONFIG = {
         'auto_stop_enabled': True,
         'auto_delete_enabled': True,
         'auto_purge_enabled': True
+    },
+    'logging': {
+        'llm_enqueue_enabled': True
     }
 }
 
@@ -120,6 +123,17 @@ def get_feature_auto_purge_enabled(headers: dict | None = None) -> bool:
             return str(header_value).lower() == "true"
     return _APP_CONFIG.get('mcp_features', {}).get('auto_purge_enabled', DEFAULT_APP_CONFIG['mcp_features']['auto_purge_enabled'])
 
+# --- Logging Configuration Accessors ---
+
+def get_llm_enqueue_enabled() -> bool:
+    """Returns whether LLM logging should use enqueue for thread safety."""
+    return _APP_CONFIG.get('logging', {}).get('llm_enqueue_enabled', DEFAULT_APP_CONFIG['logging']['llm_enqueue_enabled'])
+
+def get_interface_debug_enabled() -> bool:
+    """Returns whether detailed interface debug logging is enabled."""
+    # Check the logging config (logging_config.yaml) where this setting belongs
+    return LOGGING_CONFIG.get('interface_debug_enabled', False)
+
 # --- Specific Config Values ---
 
 # Load API keys using nested gets for safety
@@ -145,6 +159,11 @@ print("\nMCP Feature Flags:")
 print(f"  Auto-Stop Enabled: {get_feature_auto_stop_enabled()}")
 print(f"  Auto-Delete Enabled: {get_feature_auto_delete_enabled()}")
 print(f"  Auto-Purge Enabled: {get_feature_auto_purge_enabled()}")
+
+# Print Logging Configuration status
+print("\nLogging Configuration:")
+print(f"  LLM Enqueue Enabled: {get_llm_enqueue_enabled()}")
+print(f"  Interface Debug Enabled: {get_interface_debug_enabled()}")
 
 # --- Deprecated Functions (Keep temporarily for reference/smooth transition if needed, but remove eventually) ---
 


### PR DESCRIPTION
I dont have a current subscription to Gemini LLM's via the API so these fixes are somewhat speculative.  If the problem still repeats try adding the configuration to your config.yaml file:

# Logging configuration
logging:
  # Enable/disable thread-safe logging queue for LLM debug logs
  # Setting to false may resolve pickle serialization errors with Google Protocol Buffers
  # but may reduce thread safety in high-concurrency scenarios
  llm_enqueue_enabled: false  # Set to false if experiencing MapComposite pickle errors

Changes
1. Fixed MapComposite Serialization Issue (Solution #1)
Files Modified:
nifi_chat_ui/chat_manager.py - Enhanced _safe_part_to_dict() function and args handling
What was fixed:
Improved handling of Google Protocol Buffer MapComposite objects that were causing pickle errors
Added recursive conversion of complex objects to serializable types
Added better error handling with fallbacks for serialization failures
Applied the fix to both the logging serialization and the tool call processing

2. Added Configuration Option for LLM Enqueue
Files Modified:
config.example.yaml - Added new logging section with llm_enqueue_enabled option
config/settings.py - Added configuration accessors and defaults
config/logging_setup.py - Modified to use the new configuration option
What was added:
logging.llm_enqueue_enabled configuration option (defaults to true)
