### PR TITLE
Feature/mtls client cert auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ nifi_chat_ui/system_prompt copy 2.md
 .cursor/plans/
 .pytest_cache/
 flow_exports/
+.mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ docs/plans/
 docs/libdocs/
 chat_history.db
 nifi_tokens.json
+certs/
 nifi_chat_ui/system_prompt copy 2.md
 .cursor/plans/
 .pytest_cache/

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,32 @@
+{
+  "mcpServers": {
+    "nifi": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/absolute/path/to/NiFiMCP",
+        "python",
+        "-m",
+        "nifi_mcp_server.stdio_server"
+      ],
+      "env": {
+        "NIFI_SERVER_ID": "nifi-dev"
+      }
+    },
+    "nifi-prod": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/absolute/path/to/NiFiMCP",
+        "python",
+        "-m",
+        "nifi_mcp_server.stdio_server"
+      ],
+      "env": {
+        "NIFI_SERVER_ID": "nifi-prod"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Model Context Protocol (MCP) server exposing ~30 tools for interacting with Apache NiFi (tested on 1.23/1.28, expected to work on 2.x while the REST API stays consistent). It runs in two modes that share the same tool implementations:
+
+1. **Stdio MCP server** — for IDE/agent clients (Cursor, Claude Code, etc.). Entry: `nifi_mcp_server/stdio_server.py`. No REST server or UI needed.
+2. **REST server + browser chat bot** — the FastMCP tools are wrapped in a FastAPI app (`nifi_mcp_server/server.py`) that a separate FastAPI chat UI (`api/main.py`) calls over HTTP.
+
+## Common commands
+
+```bash
+uv sync                      # install deps from pyproject.toml + uv.lock (run after pulling, deps change often)
+
+# Stdio MCP server (any MCP client)
+uv run python -m nifi_mcp_server.stdio_server        # NIFI_SERVER_ID env selects server; defaults to first in config.yaml
+
+# Built-in chat bot — TWO processes in two terminals:
+uvicorn nifi_mcp_server.server:app --reload --port 8000   # 1. MCP/NiFi backend
+uvicorn api.main:app --reload --port 3000                 # 2. chat UI, then open http://localhost:3000
+# If backend is not on 8000, set MCP_SERVER_PORT to its port for BOTH the UI process and tests.
+
+# Tests
+python -m pytest                                  # all
+python -m pytest -m unit                          # unit only (no NiFi server needed, ~0.4s)
+python -m pytest -m "not slow"                    # skip slow tests
+python -m pytest tests/core_operations/test_nifi_processor_operations.py   # single file
+python -m pytest tests/path::test_name -v -s      # single test, verbose, with logs
+python tests/cleanup_test_pgs.py                  # clean leftover test process groups in NiFi
+```
+
+There is no separate lint/format step configured.
+
+## Configuration
+
+- `config.yaml` (gitignored; copy from `config.example.yaml`) holds NiFi server list and LLM API keys. The chat bot needs LLM keys; pure MCP usage does not.
+- Each NiFi server entry has an `id` (used everywhere to select a server). Auth options: basic auth (`username`/`password`), OIDC bearer token, or mTLS client cert (`client_cert`/`client_key`, plus `host_header` when reaching NiFi via localhost/port-forward). `tls_verify: false` for self-signed dev certs.
+- `config/settings.py` loads YAML, merges defaults, and is the single source for config access (`get_nifi_server_config`, `get_nifi_servers`, workflow/timeout settings). Many settings have env overrides (e.g. `NIFI_SERVER_ID`, `MCP_SERVER_PORT`, `NIFI_AUTO_STOP_VERIFY_SECONDS`).
+
+### Secrets — do not read or commit
+`config.yaml`, `nifi_tokens.json`, and `certs/` contain live credentials. Never read these files, print their contents, or commit them. OIDC tokens live in `nifi_tokens.json` (file-based store shared across processes, ~5 min expiry) — see `TOKEN_MANAGEMENT.md` for the token submit/check workflow via `test_doc_workflow_auto.py`.
+
+## Architecture
+
+### Tool layer (`nifi_mcp_server/`)
+- `core.py` — creates the shared `FastMCP` instance (`mcp`), the NiFi client factory (`get_nifi_client` authenticates eagerly; `create_nifi_client` defers auth — used by stdio so startup never blocks on NiFi), and the `handle_nifi_errors` decorator that implements **Auto-Stop remediation** (on a "component is running" error it stops the parent process group and retries once).
+- `nifi_client.py` (~2900 lines) — `NiFiClient`, the async httpx wrapper over the NiFi REST API. All HTTP, auth (token/basic/mTLS), and entity CRUD live here.
+- `api_tools/` — the actual MCP tools, grouped by operational phase: `review.py` (list/get/document — read-only), `creation.py`, `modification.py`, `operation.py` (start/stop/purge), `helpers.py`, and `control.py` (MCP-only session/server/phase tools, hidden from the web UI). `utils.py` holds shared formatting/filtering helpers and the phase machinery.
+- `server.py` and `stdio_server.py` are thin entrypoints. **Both import every `api_tools` module for its registration side effects** — adding a tool module means adding the import to both files.
+
+### Tool phases (important)
+Tools are tagged with `@tool_phases([...])` listing which of `Review | Build | Modify | Operate` they belong to. The current phase is set per-session via the `set_nifi_phase` control tool; when a phase is active, only tools tagged for it are runnable. `CONTROL_TOOL_NAMES` (`get_nifi_session_info`, `set_nifi_server`, `set_nifi_phase`) are always allowed. This narrows the tool surface the LLM sees so it doesn't, e.g., delete things during a review. The decorator also accumulates per-session token counts.
+
+### Request context (`request_context.py`)
+Per-request state (selected NiFi client, server id, logger, user/action ids, session token counters) flows through `contextvars` rather than function args. Tools read the active client via `current_nifi_client.get()`. This is why tools don't take a client parameter.
+
+### Chat UI (`api/` + `nifi_chat_ui/`)
+- `api/main.py` — FastAPI app serving the static frontend (`static/`) and WebSocket (`/ws`) for live workflow updates; routers in `api/chat_api.py`, `api/settings_api.py`, `api/diagram_api.py`.
+- `nifi_chat_ui/llm/` — modular multi-provider LLM layer. `providers/` (anthropic, openai, gemini, perplexity) behind `factory.py`; `chat_manager.py` orchestrates LLM calls + tool execution; `mcp/client.py` is the HTTP client that calls the REST tool endpoints. `mcp_handler.py` (older interface) targets the backend via `MCP_SERVER_URL`/`MCP_SERVER_PORT`.
+
+### Workflows (`nifi_mcp_server/workflows/`)
+A guided/unguided workflow engine (built on `pocketflow`) for multi-step LLM-driven tasks like flow documentation. `registry.py` registers `WorkflowDefinition`s; `nodes/` are workflow steps, `prompts/` the prompt sequences, `definitions/` the concrete workflows. Enabled workflows are listed under `workflows.enabled_workflows` in config. The flagship is `flow_documentation`; see `flow_documenter.py` / `flow_documenter_improved.py` and `docs/flow-doc-workflow/`.
+
+## Conventions
+
+- Async throughout — tools and the NiFi client are `async`; the stdio server runs via `anyio.run`.
+- Logging is `loguru`, configured by `config/logging_setup.py` (writes to `logs/`). Prefer the context-bound logger (`current_request_logger.get()`) inside tools.
+- MCP server-instruction text (orchestration guidance injected into clients) lives in `nifi_mcp_server/mcp_instructions.txt`. Longer-form agent guidance is `docs/MCP-Agent-Guide.md`.
+- Test placement: pure-logic tests (mocked, no server) go in `tests/unit/` and are marked `unit`; tests hitting a real NiFi go in `tests/core_operations/` etc. and are marked `integration`. Integration tests use fixtures (`test_pg`, ...) that auto-clean the NiFi objects they create — always use them rather than creating PGs by hand. See `tests/README.md`.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,6 +7,10 @@ nifi:
       username: "" # Optional: Username for NiFi basic auth
       password: "" # Optional: Password for NiFi basic auth - DO NOT COMMIT REAL PASSWORDS
       tls_verify: false # Set to true for valid certs, false for self-signed (dev only)
+      # mTLS client-cert auth (no token/browser; for cert-secured NiFi). Uncomment to use:
+      # client_cert: "certs/nifi-mcp-client.crt"  # PEM client certificate
+      # client_key: "certs/nifi-mcp-client.key"   # PEM private key
+      # host_header: "nifi.internal.example.com"  # only needed via localhost/port-forward (SNI/Host override)
     # Add more NiFi server configurations here as needed
     # - id: "nifi-dev-example"
     #   name: "Development NiFi Example"

--- a/nifi_mcp_server/core.py
+++ b/nifi_mcp_server/core.py
@@ -108,7 +108,10 @@ async def get_nifi_client(server_id: str, bound_logger = logger) -> NiFiClient:
         username=server_conf.get('username'),  # May be None
         password=server_conf.get('password'),  # May be None
         tls_verify=server_conf.get('tls_verify', True),
-        credential_callback=credential_callback
+        credential_callback=credential_callback,
+        client_cert=server_conf.get('client_cert'),
+        client_key=server_conf.get('client_key'),
+        host_header=server_conf.get('host_header'),
     )
     bound_logger.debug(f"Instantiated NiFiClient for {server_conf.get('url')}")
 
@@ -154,6 +157,9 @@ async def create_nifi_client(server_id: str, bound_logger = logger) -> NiFiClien
         tls_verify=server_conf.get("tls_verify", True),
         credential_callback=credential_callback,
         server_id=server_id,
+        client_cert=server_conf.get("client_cert"),
+        client_key=server_conf.get("client_key"),
+        host_header=server_conf.get("host_header"),
     )
     bound_logger.debug(f"Instantiated un-authenticated NiFiClient for {server_conf.get('url')}")
     return client

--- a/nifi_mcp_server/nifi_client.py
+++ b/nifi_mcp_server/nifi_client.py
@@ -55,9 +55,11 @@ class AuthParams:
 class NiFiClient:
     """A simple asynchronous client for the NiFi REST API."""
 
-    def __init__(self, base_url: str, username: Optional[str] = None, password: Optional[str] = None, 
+    def __init__(self, base_url: str, username: Optional[str] = None, password: Optional[str] = None,
                  tls_verify: bool = True, credential_callback: Optional[Callable[[str], Awaitable[Tuple[str, str]]]] = None,
-                 server_id: Optional[str] = None):
+                 server_id: Optional[str] = None,
+                 client_cert: Optional[str] = None, client_key: Optional[str] = None,
+                 host_header: Optional[str] = None):
         """Initializes the NiFiClient.
 
         Args:
@@ -74,6 +76,13 @@ class NiFiClient:
         self.username = username
         self.password = password
         self.tls_verify = tls_verify
+        # mTLS client-cert auth: when both are set, identity comes from the TLS cert
+        # (no token/login). host_header overrides the Host header when connecting via
+        # localhost/port-forward so NiFi's proxy-host whitelist is satisfied.
+        self.client_cert = client_cert
+        self.client_key = client_key
+        self.host_header = host_header
+        self._cert_mode = bool(client_cert and client_key)
         self.credential_callback = credential_callback
         self._client = None
         self._token = None
@@ -88,8 +97,8 @@ class NiFiClient:
 
     @property
     def is_authenticated(self) -> bool:
-        """Checks if the client currently holds an authentication token."""
-        return self._token is not None
+        """Cert-mode needs no token; otherwise a bearer token must be present."""
+        return self._cert_mode or self._token is not None
 
     async def _ensure_authenticated(self) -> None:
         """Authenticate on-demand when the token is missing.
@@ -97,6 +106,8 @@ class NiFiClient:
         This allows the MCP stdio server to start without making any network calls,
         and only connect/authenticate on the first actual NiFi API operation.
         """
+        if self._cert_mode:
+            return  # TLS client cert is the identity; no token needed
         if self._token is not None:
             return
         await self.authenticate(server_id=self._server_id)
@@ -112,7 +123,11 @@ class NiFiClient:
 
         headers = {}
         cookies = {}
-        if self._token:
+        if self._cert_mode:
+            # Identity is the TLS client cert — no Authorization header / cookie.
+            if self.host_header:
+                headers["Host"] = self.host_header
+        elif self._token:
             headers["Authorization"] = f"Bearer {self._token}"
             # Only send cookie for OIDC tokens. NiFi 1.x username/password auth uses /access/token;
             # sending __Secure-Authorization-Bearer can cause 403 on mutate operations when NiFi
@@ -120,13 +135,17 @@ class NiFiClient:
             if self._token_from_oidc:
                 cookies["__Secure-Authorization-Bearer"] = self._token
 
-        self._client = httpx.AsyncClient(
+        client_kwargs = dict(
             base_url=self.base_url,
             verify=self.tls_verify,
             headers=headers,
             cookies=cookies if cookies else None,
-            timeout=30.0 # Keep timeout
+            timeout=30.0,  # Keep timeout
         )
+        if self._cert_mode:
+            client_kwargs["cert"] = (self.client_cert, self.client_key)
+
+        self._client = httpx.AsyncClient(**client_kwargs)
         return self._client
 
     async def get_authentication_config(self) -> Dict[str, Any]:
@@ -296,6 +315,32 @@ class NiFiClient:
         Args:
             server_id: Optional server ID for credential callback context.
         """
+        # Prefer an explicitly provided access token (e.g. a JWT placed in the
+        # token store) when no username/password is configured. This lets a bearer
+        # token work even when the server does not advertise externalLoginRequired
+        # (e.g. cert-secured / mTLS servers), without overriding an explicit
+        # username/password config, which keeps its prior precedence (the OIDC
+        # branch below still handles stored tokens for externalLoginRequired servers).
+        username_password_configured = bool((self.username or "").strip() and (self.password or ""))
+        if server_id and not username_password_configured:
+            from nifi_mcp_server.token_store import get_token
+            stored_token = get_token(server_id)
+            if stored_token:
+                token = stored_token.strip()
+                if len(token.split('.')) != 3:
+                    logger.warning(
+                        f"Stored token for {server_id} is not JWT-shaped; using as-is"
+                    )
+                self._token = token
+                self._token_from_oidc = True
+                if self._client:
+                    await self._client.aclose()
+                self._client = None
+                logger.info(
+                    f"Using stored access token for server {server_id} (length: {len(token)})"
+                )
+                return
+
         # Get authentication configuration
         auth_config = await self.get_authentication_config()
         auth_config_data = auth_config.get("authenticationConfiguration", {})

--- a/tests/unit/test_nifi_client_mtls.py
+++ b/tests/unit/test_nifi_client_mtls.py
@@ -1,0 +1,109 @@
+"""Unit tests for mTLS client-certificate authentication in NiFiClient.
+
+Verifies the cert-mode behaviour: when both client_cert and client_key are
+configured, identity comes from the TLS client certificate, so no token/login
+is required. All offline — no NiFi connectivity needed.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from nifi_mcp_server.nifi_client import NiFiClient
+
+BASE_URL = "https://nifi.example.com/nifi-api"
+
+
+def _make_client(**kwargs):
+    return NiFiClient(base_url=BASE_URL, **kwargs)
+
+
+def test_cert_mode_enabled_only_when_both_cert_and_key_present():
+    assert _make_client(client_cert="c.crt", client_key="c.key")._cert_mode is True
+    assert _make_client(client_cert="c.crt")._cert_mode is False
+    assert _make_client(client_key="c.key")._cert_mode is False
+    assert _make_client()._cert_mode is False
+
+
+def test_is_authenticated_true_in_cert_mode_without_token():
+    client = _make_client(client_cert="c.crt", client_key="c.key")
+    assert client._token is None
+    assert client.is_authenticated is True
+
+
+def test_is_authenticated_false_without_cert_or_token():
+    assert _make_client().is_authenticated is False
+
+
+@pytest.mark.anyio
+async def test_ensure_authenticated_skips_network_in_cert_mode():
+    """Cert mode must not trigger a login/network call."""
+    client = _make_client(client_cert="c.crt", client_key="c.key")
+    client.authenticate = AsyncMock()
+    await client._ensure_authenticated()
+    client.authenticate.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_ensure_authenticated_authenticates_when_not_cert_mode():
+    client = _make_client()
+    client.authenticate = AsyncMock()
+    await client._ensure_authenticated()
+    client.authenticate.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_get_client_uses_client_cert_and_sends_no_auth_header_in_cert_mode():
+    client = _make_client(client_cert="c.crt", client_key="c.key", tls_verify=False)
+    with patch("nifi_mcp_server.nifi_client.httpx.AsyncClient") as mock_async_client:
+        await client._get_client()
+    kwargs = mock_async_client.call_args.kwargs
+    assert kwargs["cert"] == ("c.crt", "c.key")
+    assert kwargs["verify"] is False
+    assert "Authorization" not in kwargs["headers"]
+
+
+@pytest.mark.anyio
+async def test_get_client_sets_host_header_when_configured():
+    client = _make_client(
+        client_cert="c.crt", client_key="c.key", host_header="nifi.internal.example.com"
+    )
+    with patch("nifi_mcp_server.nifi_client.httpx.AsyncClient") as mock_async_client:
+        await client._get_client()
+    kwargs = mock_async_client.call_args.kwargs
+    assert kwargs["headers"].get("Host") == "nifi.internal.example.com"
+
+
+@pytest.mark.anyio
+async def test_get_client_omits_cert_and_uses_bearer_when_not_cert_mode():
+    client = _make_client()
+    client._token = "tok"
+    with patch("nifi_mcp_server.nifi_client.httpx.AsyncClient") as mock_async_client:
+        await client._get_client()
+    kwargs = mock_async_client.call_args.kwargs
+    assert "cert" not in kwargs
+    assert kwargs["headers"]["Authorization"] == "Bearer tok"
+
+
+@pytest.mark.anyio
+async def test_authenticate_uses_stored_token_when_no_userpass():
+    """With no username/password, a stored token short-circuits before auth-config."""
+    client = _make_client()  # no username/password
+    with patch("nifi_mcp_server.token_store.get_token", return_value="a.b.c"), \
+         patch.object(client, "get_authentication_config", new=AsyncMock()) as get_config:
+        await client.authenticate(server_id="srv")
+    assert client._token == "a.b.c"
+    assert client._token_from_oidc is True
+    get_config.assert_not_awaited()  # never reached the auth-config path
+
+
+@pytest.mark.anyio
+async def test_authenticate_does_not_override_configured_userpass():
+    """An explicit username/password keeps precedence: the stored-token short-circuit
+    is skipped and we fall through to the normal auth-config path."""
+    client = _make_client(username="u", password="p")
+    sentinel = RuntimeError("fell through to auth-config")
+    with patch("nifi_mcp_server.token_store.get_token", return_value="a.b.c"), \
+         patch.object(client, "get_authentication_config", new=AsyncMock(side_effect=sentinel)):
+        with pytest.raises(RuntimeError, match="fell through"):
+            await client.authenticate(server_id="srv")
+    assert client._token is None  # stored token was NOT applied


### PR DESCRIPTION
Add mTLS client-certificate authentication for NiFi

Summary

Adds support for authenticating to NiFi via a TLS client certificate (mTLS), so the MCP server can talk to cert-secured NiFi instances with no token, login, or browser flow. Also includes a stored-token fallback for bearer-secured servers and project onboarding docs.

What's included

mTLS client-cert auth (nifi_mcp_server/nifi_client.py, core.py)
- NiFiClient accepts client_cert, client_key, and host_header. When cert + key are present, the client runs in "cert mode": identity comes from the TLS cert, so no Authorization header, cookie, or token round-trip is used, and is_authenticated/_ensure_authenticated short-circuit.
- host_header overrides the Host header for localhost/port-forward setups, so NiFi's proxy-host whitelist is satisfied.
- The client factory in core.py threads the three new config fields through.

Stored-token fallback (nifi_client.py authenticate)
- When no username/password is configured, an access token placed in the token store is used directly, letting a bearer token work against servers that don't advertise externalLoginRequired, without changing existing username/password or OIDC precedence.

Config & docs
- config.example.yaml documents the new client_cert / client_key / host_header options.
- New CLAUDE.md with build/run/test commands and architecture notes; .mcp.json.example template for stdio MCP clients; .gitignore now excludes .mcp.json.

Testing
- Adds tests/unit/test_nifi_client_mtls.py (unit, no live server) covering cert-mode behavior.
- Run: python -m pytest tests/unit/test_nifi_client_mtls.py -v

Notes
- Certs and credentials are kept out of version control (certs/, config.yaml, nifi_tokens.json remain gitignored).
